### PR TITLE
hotsync: Fix a compilation error

### DIFF
--- a/src/condmgr.rs
+++ b/src/condmgr.rs
@@ -11,7 +11,7 @@ use crate::{
     error::{ConduitError, ConduitRegistrationError},
 };
 
-const COND_MGR_BIN: &[u8] = include_bytes!("../include/Condmgr.dll");
+const COND_MGR_BIN: &[u8] = include_bytes!("../include/condmgr.dll");
 
 #[derive(Debug)]
 pub struct ConduitInstallation {


### PR DESCRIPTION
Building the conduit on Linux systems causes an invalid import error. The problem is generated by the fact the Linux is case sensitive.

Fix the issue using the correct casing.

Note: The patch can be tested using the docker container at [1].

[1] https://github.com/fvincenzo/linux-rust-debian